### PR TITLE
Implemented .gitnuke behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fts_gitignore_nuke"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "cactus",

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 fts_gitignore_nuke is a Rust-written CLI tool to find files and folders hidden by .gitignore files so they can be deleted.
 
-This is useful because it allows deleting build output from many projects in one action. All operations are performed manually and `git` is never invoked. This is because `.gitignore` files are increasingly used in contexts outside Git. For example Mercurial, Perforce or custom tooling may leverage `.gitignore` files.
+This is useful because it allows deleting build output from many projects in one action. All operations are performed manually and `git` is never invoked. This is because `.gitignore` files are increasingly used in contexts outside Git. For example Mercurial, perforce or custom tooling may leverage `.gitignore` files.
 
 ![](/screenshots/nuclear_launch.png?raw=true)
 
@@ -40,8 +40,54 @@ OPTIONS:
 
 # Support
 
-`fts_gitignore_nuke` was built for Windows. It should work on other platforms, but has not been tested. This tool was written for personal use cases and may require slight modification to support different environments or workflows. Pull requests welcome!
+`fts_gitignore_nuke` was built for Windows. It has also been tested on Ubuntu, and should support other platforms. This tool was written for personal use cases and may require slight modification to support different environments or workflows. Pull requests welcome!
 
 # Performance
 
 `fts_gitignore_nuke` is relatively fast and multithreaded by default. Disk IO is the clear bottleneck.
+
+
+# How to prevent critical files from being deleted ?
+
+After loading `.gitignore`, `fts_gitignore_nuke` will also look for `.gitnuke`. Any pattern included or excluded from `.gitnuke` has higher precedence than whatever is in `.gitignore`.
+
+Additionally, `fts_gitignore_nuke` will NEVER delete any of the following:
+* `.git`
+* `.hg`
+* `.gitignore`
+* `.gitnuke`
+
+You may safely add any of these patterns to your `.gitignore` (or even `.gitnuke`), the corresponding items will not be removed.
+
+As an example, the three following patterns are absolutely equivalent, and will result in the same files being deleted regardless of the layout of the directory tree.
+
+```
+.gitignore
+    foo/*
+    bar
+    baz/quux
+```
+```
+.gitignore
+    foo/*
+
+.gitnuke
+    bar
+    baz/quux
+    .gitignore
+```
+```
+.gitignore
+    foo/*
+    bar
+    baz/quux
+    spam
+    eggs/*
+    .gitnuke
+
+.gitnuke
+    !spam
+    !eggs/*
+```
+
+Despite this mechanism, you should still carefully review the list of files to be deleted before nuking them.

--- a/src/job_system.rs
+++ b/src/job_system.rs
@@ -2,12 +2,12 @@ use crossbeam_deque::{Injector, Stealer, Worker};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-pub fn run_recursive_job<IN,OUT,JOB>(initial: Vec<IN>, job: JOB, num_workers: usize) -> Vec<OUT> 
-where 
+pub fn run_recursive_job<IN,OUT,JOB>(initial: Vec<IN>, job: JOB, num_workers: usize) -> Vec<OUT>
+where
     IN: Send,
     OUT: Send,
     JOB: Fn(IN, &Worker<IN>) -> Option<OUT> + Clone + Send,
-{   
+{
     // Create crossbeam_deque injector/worker/stealers
     let injector = Injector::new();
     let workers : Vec<_> = (0..num_workers).map(|_| Worker::new_lifo()).collect();
@@ -21,13 +21,13 @@ where
 
     // Create single scope to contain all workers
     let result : Vec<OUT> = crossbeam_utils::thread::scope(|scope|
-    {   
+    {
         // Container for all workers
         let mut worker_scopes : Vec<_> = Default::default();
 
         // Create each worker
         for worker in workers.into_iter() {
-            
+
             // Make copy of data so we can move clones or references into closure
             let injector_borrow = &injector;
             let stealers_copy = stealers.clone();
@@ -54,7 +54,7 @@ where
                             if let Some(result) = job_copy(item, &worker) {
                                 worker_results.push(result);
                             }
-                        } 
+                        }
                     }
 
                     // no work, check if all workers are idle
@@ -188,7 +188,7 @@ fn biggest_recursive_job() {
     // ∑(1..n) = n(n+1)/2
     // job code returns n*2 so drop /2
     let expected_result : u64 = data.iter()
-        .map(|x| (x*(x+1))) 
+        .map(|x| (x*(x+1)))
         .sum();
 
     let result = run_recursive_job(data.clone(), job, 1);
@@ -196,4 +196,4 @@ fn biggest_recursive_job() {
 
     let result = run_recursive_job(data, job, 6);
     assert_eq!(result.iter().sum::<u64>(), expected_result);
-} 
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod job_system;
 
 #[derive(StructOpt, Debug)]
 #[structopt(
-    name = "☢️ fts_gitignore_nuke ☢️", 
+    name = "☢️ fts_gitignore_nuke ☢️",
     author = "Forrest Smith <forrestthewoods@gmail.com>",
     about = "Deletes files hidden by .gitignore files",
 )
@@ -155,7 +155,7 @@ fn main() -> anyhow::Result<()> {
     // Return value is result for the path only. Sub-directories will run separately
     // and return their own result.
     let recursive_job = |(mut ignore_tip, path): (ArcCactus<Gitignore>, PathBuf), worker: &Worker<_>| -> Option<Vec<PathBuf>> {
-        
+
         let mut job_ignores : Vec<_> = Default::default();
 
         // Get iterator to directory children
@@ -193,7 +193,7 @@ fn main() -> anyhow::Result<()> {
                 let ignore_match = ignore_tip.vals()
                     .map(|i| i.matched(&child_path, is_dir))
                     .find(|m| !m.is_none());
-                
+
                 // Handle ignored/whitelisted/neither
                 match ignore_match {
                     Some(m) => {
@@ -203,7 +203,7 @@ fn main() -> anyhow::Result<()> {
                             println!("Glob [{:?}] from Gitignore [{:?}] matched path [{:?}]",
                                 glob.original(), glob.from(), child_path);
                         }
-    
+
                         // Add ignores to the list. Do nothing if whitelisted
                         if m.is_ignore() {
                             job_ignores.push(child_path);
@@ -224,9 +224,9 @@ fn main() -> anyhow::Result<()> {
             }();
 
             // Print error if child could not be checked
-            check_error(result);           
+            check_error(result);
         }
-        
+
         // Return ignored paths for path
         Some(job_ignores)
     };
@@ -241,7 +241,7 @@ fn main() -> anyhow::Result<()> {
         .flatten()
         .enumerate()
         .collect();
-    
+
     // Second recursive job to compute size of ignored directories
     let recursive_dir_size_job = |(root_idx, path): (usize, PathBuf), worker: &Worker<_>| -> Option<(usize, u64)> {
         // Get type of path
@@ -279,7 +279,7 @@ fn main() -> anyhow::Result<()> {
             }();
             check_error(result);
         }
-        
+
         Some((root_idx, files_size))
     };
 
@@ -317,7 +317,7 @@ fn main() -> anyhow::Result<()> {
     }
     println!("Total Bytes: {}", total_bytes.to_formatted_string(&Locale::en));
     println!("Time: {:?}", start.elapsed());
-    
+
     // Skip NUKE op in benchmark mode
     if opt.benchmark {
         return Ok(());
@@ -334,7 +334,7 @@ fn main() -> anyhow::Result<()> {
         let result = || -> anyhow::Result<()> {
             let meta = fs::metadata(&path)
                 .with_context(|| format!("{} {}", "fs::metadata", path.display()))?;
-            
+
             // Remove file or directory
             if meta.is_file() {
                 std::fs::remove_file(&path)
@@ -347,7 +347,7 @@ fn main() -> anyhow::Result<()> {
             Ok(())
         }();
 
-        // Always print removal errors 
+        // Always print removal errors
         match result {
             Ok(_) => (),
             Err(e) => println!("Error: {}", e)
@@ -372,7 +372,7 @@ fn main() -> anyhow::Result<()> {
 
             println!("☠️☠️☠️ nuclear deletion complete ☠️☠️☠️");
             break;
-        } 
+        }
         else if trimmed_input.eq_ignore_ascii_case(QUIT_STRING) {
             println!("😇😇😇 Nuclear launch aborted. Thank you and have a nice day. 😇😇😇");
             break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod job_system;
     name = "☢️ fts_gitignore_nuke ☢️",
     author = "Forrest Smith <forrestthewoods@gmail.com>",
     about = "Deletes files hidden by .gitignore files.
-If a .gitnuke is found its patterns will be used with higher precedence that any .gitignore from the same directory.",
+If a .gitnuke is found its patterns will be used with higher precedence than any .gitignore from the same directory.",
 )
 ]
 struct Opts {


### PR DESCRIPTION
As explained in the `readme.md` section added, `.gitnuke` files are invisible to `git` but are read by `fts_gitignore_nuke` with higher precedence than `.gitignore`. This part of the PR was implemented in the second commit.

The third commit addresses an issue that was found: adding `.gitnuke` to `.gitignore` would delete it. As I would assume it to be normal to almost always exclude `.gitnuke` from an online repo, I figured that this problem should be fixed, and found a -- perhaps not the most elegant -- way to do it by filtering on the file list just after checking for the minimum file size. I have never seen what a `.hg` file is, but seeing as it was part of the global whitelist I assumed it was important to exclude it.

Fourth commit added information to the `readme` and the docstring, along with an example which was deemed necessary seeing that behavior became a bit less intuitive.

First commit was due to my text editor auto-deleting trailing whitespace and adding a newline at the end of the file. I could have re-added these manually, but I decided it was not worth it. I would suggest using `rustfmt` in the future. I did not run `cargo fmt` myself because it would have resulted in ~140 lines modified.