### PR TITLE
add support for dry-runs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ FLAGS:
         --include-global-ignore    Include global .gitignore for matches
         --print-errors             Prints errors if encountered
         --print-glob-matches       Prints which glob and which .gitignore matched each path
+        --dry-run                  Preview which files will be nuked
     -V, --version                  Prints version information
 
 OPTIONS:

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,9 @@ struct Opts {
 
     #[structopt(long, help = "Prints errors if encountered")]
     print_errors: bool,
+
+    #[structopt(long, help = "Preview which files will be nuked")]
+    dry_run: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -348,8 +351,8 @@ fn main() -> anyhow::Result<()> {
     println!("Total Bytes: {}", total_bytes.to_formatted_string(&Locale::en));
     println!("Time: {:?}", start.elapsed());
 
-    // Skip NUKE op in benchmark mode
-    if opt.benchmark {
+    // Skip NUKE op in benchmark and dry-run modes
+    if opt.benchmark || opt.dry_run {
         return Ok(());
     }
 


### PR DESCRIPTION
Allows for stdout to be piped to other tools.

I wanted to verify that my .gitnuke rules were correct without having to manually scroll through the large list of files by running the results through grep. 